### PR TITLE
create 'mbcharts/year' folder if it doesn't already exist

### DIFF
--- a/mbdbfiles/addtoyear.php
+++ b/mbdbfiles/addtoyear.php
@@ -9,6 +9,13 @@ if (!$result1) die('Couldn\'t fetch records');
 $num_fields = mysqli_num_fields($result1); 
 $headers2 = array(); 
 
+#Create mbcharts/year folder if it doesn't exist
+if (!file_exists('../mbcharts/'.$weatherfileyear.'/')) {
+    $oldmask = umask(0);
+    mkdir('../mbcharts/'.$weatherfileyear, 0775, true);
+    umask($oldmask);
+}
+
 $fp = fopen('../mbcharts/'.$weatherfileyear.'.csv', 'a+'); 
 $fp1 = fopen('../mbcharts/'.$weatherfileyear.'/'.$weatherfilemonth.'.csv', 'a+'); 
 if ($fp && $result1) 


### PR DESCRIPTION
Since the 'mbcharts/year' folders aren't included because github won't upload an empty folder, let's go ahead and create the current year's folder if it doesn't already exist each time the script is run.